### PR TITLE
Fix reentrancy vulnerability

### DIFF
--- a/contract/SimpleNftLowerGas.sol
+++ b/contract/SimpleNftLowerGas.sol
@@ -20,8 +20,10 @@ pragma solidity >=0.7.0 <0.9.0;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract SimpleNftLowerGas is ERC721, Ownable {
+
+contract SimpleNftLowerGas is ERC721, Ownable, ReentrancyGuard {
   using Strings for uint256;
   using Counters for Counters.Counter;
 
@@ -138,7 +140,7 @@ contract SimpleNftLowerGas is ERC721, Ownable {
     paused = _state;
   }
 
-  function withdraw() public onlyOwner {
+  function withdraw() public onlyOwner nonReentrant {
     // This will pay HashLips 5% of the initial sale.
     // You can remove this if you want, or keep it in to support HashLips and his channel.
     // =============================================================================


### PR DESCRIPTION
Fix re-entry vulnerability on split payment using call();
The first addr could drain all the funds.

https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/