### PR TITLE
Force solidity version > 0.8.0 to protect against under/overflows

### DIFF
--- a/contract/SimpleNft.sol
+++ b/contract/SimpleNft.sol
@@ -13,7 +13,7 @@
     to the best of the developers' knowledge to work as intended.
 */
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contract/SimpleNftLowerGas.sol
+++ b/contract/SimpleNftLowerGas.sol
@@ -15,7 +15,7 @@
     using the code for your own project.
 */
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";


### PR DESCRIPTION
Minor modification to prevent under/overflows (in mint function in case the parameters are set badly by an owner).


https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/ > "The change that will affect most users is that arithmetic operations are now checked by default, which means that overflow and underflow will cause a revert. This feature can be disabled locally by using an unchecked block."